### PR TITLE
Add update_details_panel for right/left

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -395,6 +395,7 @@ impl<'a> UI<'a> {
                                     self.episode_menu.deactivate();
                                 }
                             }
+                            self.update_details_panel();
                         }
                     }
 
@@ -408,6 +409,7 @@ impl<'a> UI<'a> {
                                 }
                                 ActiveMenu::EpisodeMenu => (),
                             }
+                            self.update_details_panel();
                         }
                     }
 


### PR DESCRIPTION
The details panel is "detaching" from the episode panel
when going right/left this still happens, but now it is consistent with up/down
and it happens for a short amount of time.