### PR TITLE
ask for confirmation before removing podcasts or episodes

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -579,6 +579,11 @@ impl<'a> UI<'a> {
 
     /// Remove a podcast from the list.
     pub fn remove_podcast(&mut self, curr_pod_id: Option<i64>) -> Option<UiMsg> {
+        let confirm = self.ask_for_confirmation("Are you sure you want to remove the podcast?");
+        // If we don't get a confirmation to delete, then don't remove
+        if !confirm {
+            return None;
+        }
         let mut delete = false;
 
         if let Some(pod_id) = curr_pod_id {
@@ -604,6 +609,11 @@ impl<'a> UI<'a> {
         curr_ep_id: Option<i64>,
     ) -> Option<UiMsg>
     {
+        let confirm = self.ask_for_confirmation("Are you sure you want to remove the episode?");
+        // If we don't get a confirmation to delete, then don't remove
+        if !confirm {
+            return None;
+        }
         let mut delete = false;
         if let Some(pod_id) = curr_pod_id {
             if let Some(ep_id) = curr_ep_id {
@@ -706,6 +716,17 @@ impl<'a> UI<'a> {
             }
         }
         return any_downloaded;
+    }
+
+    /// Spawns a "(y/n)" notification with the specified input `message`
+    /// using `spawn_input_notif`. If the the user types 'y', then the 
+    /// function returns `true`, and 'n' returns `false`. Cancelling the
+    /// action returns `false` as well.
+    pub fn ask_for_confirmation(&self, message: &str) -> bool {
+        match self.spawn_yes_no_notif(message) {
+            Some(val) => val,
+            None => false
+        }
     }
 
     /// Adds a notification to the bottom of the screen that solicits


### PR DESCRIPTION
Hello, I love the terminal podcast app! About a week ago I just googled "terminal podcast app rust" and here it is! I'm relatively new to rust, and to contributing to other people's projects.

I accidentally deleted a podcast by hitting `r` and had to re-add the feed. I was already building the 1.0.1 release locally and running that, so I thought I would poke around.

What this does is add a `ask_for_confirmation` method on the `UI` struct that prompts the user like the "delete local files" prompt. Then this is used first thing in the `remove_podcast` and `remove_all_episodes` methods to confirm the remove action. This prevents accidentally removing podcasts or episodes.

If the user types 'n' or cancels then it's not confirmed and the remove is not done.

Please feel free to change anything, or I can fix anything you dislike! Also no worries if this is not even something you want to do! 